### PR TITLE
constructor for parser_exception

### DIFF
--- a/include/trie.hpp
+++ b/include/trie.hpp
@@ -5,6 +5,8 @@
 #include "bag.hpp"  // file with the implementation of your container bag<Val>
 
 struct parser_exception {
+    parser_exception(const std::string& str): m_str(str) {}
+
     std::string what() const { return m_str; }
 
 private:


### PR DESCRIPTION
Salve buongiorno a tutti.
Suggerisco la relativa modifica al file header per permettere di impostare il campo `m_str` per la struct `parser_exception`.

Grazie mille
Oleksandr Kirpachov